### PR TITLE
Adding a visibility mask computation to make masks from observer positions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,12 +51,12 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         # Install JAX first as it's a key dependency
         pip install jax
+        # Install packages with test dependencies
+        pip install -e .[test]
         # Install build dependencies
         pip install setuptools cython mpi4py
         # Install test requirements with no-build-isolation for faster builds
         pip install -r requirements-test.txt --no-build-isolation
-        # Install packages with test dependencies
-        pip install -e .[test]
         echo "numpy version installed:"
         python -c "import numpy; print(numpy.__version__)"
 

--- a/jaxpm/spherical.py
+++ b/jaxpm/spherical.py
@@ -459,10 +459,11 @@ def paint_particles_spherical(
 
     return map_hi
 
-@partial(jax.jit, static_argnames=("nside",))
+
+@partial(jax.jit, static_argnames=("nside", ))
 def spherical_visibility_mask(
-    nside: int,
-    observer_position: Array,  # normalized coords in [0,1]^3
+        nside: int,
+        observer_position: Array,  # normalized coords in [0,1]^3
 ) -> Array:
     """
     Geometric visibility mask using only nside and observer_position.
@@ -481,8 +482,8 @@ def spherical_visibility_mask(
     """
     obs = jnp.asarray(observer_position, dtype=jnp.float32)  # (3,)
     obs = jnp.clip(obs, 0.0, 1.0)
-    bmin = jnp.zeros((3,), dtype=jnp.float32)
-    bmax = jnp.ones((3,), dtype=jnp.float32)
+    bmin = jnp.zeros((3, ), dtype=jnp.float32)
+    bmax = jnp.ones((3, ), dtype=jnp.float32)
 
     npix = jhp.nside2npix(nside)
     ipix = jnp.arange(npix, dtype=jnp.int64)
@@ -493,20 +494,16 @@ def spherical_visibility_mask(
     # For axes where dir == 0, treat as parallel: if obs is inside the slab,
     # set t to (-inf, +inf); else to (+inf, -inf) so it won't intersect.
     eps = jnp.float32(1e-12)
-    inside_axis = (obs >= bmin) & (obs <= bmax)            # (3,)
-    dir_nz = jnp.abs(dirs) > eps                           # (npix, 3)
+    inside_axis = (obs >= bmin) & (obs <= bmax)  # (3,)
+    dir_nz = jnp.abs(dirs) > eps  # (npix, 3)
 
-    t1 = jnp.where(
-        dir_nz, (bmin - obs) / dirs,
-        jnp.where(inside_axis, -jnp.inf, jnp.inf)
-    )
-    t2 = jnp.where(
-        dir_nz, (bmax - obs) / dirs,
-        jnp.where(inside_axis,  jnp.inf, -jnp.inf)
-    )
+    t1 = jnp.where(dir_nz, (bmin - obs) / dirs,
+                   jnp.where(inside_axis, -jnp.inf, jnp.inf))
+    t2 = jnp.where(dir_nz, (bmax - obs) / dirs,
+                   jnp.where(inside_axis, jnp.inf, -jnp.inf))
 
-    tmin = jnp.max(jnp.minimum(t1, t2), axis=-1)           # (npix,)
-    tmax = jnp.min(jnp.maximum(t1, t2), axis=-1)           # (npix,)
+    tmin = jnp.max(jnp.minimum(t1, t2), axis=-1)  # (npix,)
+    tmax = jnp.min(jnp.maximum(t1, t2), axis=-1)  # (npix,)
 
     # Visible if the forward ray intersects: tmax >= max(tmin, 0)
     visible = tmax > jnp.maximum(tmin, jnp.float32(0.0))

--- a/tests/test_spherical_painting_methods.py
+++ b/tests/test_spherical_painting_methods.py
@@ -31,7 +31,7 @@ from jax_cosmo.redshift import redshift_distribution
 from jaxpm.distributed import fft3d
 from jaxpm.growth import growth_factor as jpm_growth_factor
 from jaxpm.pm import linear_field, lpt, pm_forces
-from jaxpm.spherical import paint_particles_spherical
+from jaxpm.spherical import paint_particles_spherical, spherical_visibility_mask
 
 # ----------------------
 # Fixed configuration
@@ -360,9 +360,35 @@ def test_spherical_painting_differentiability(positions_lpt, method, kwargs):
 
     # Smooth methods should have non-trivial gradients
     grad_magnitude = jnp.abs(gradient)
-    assert grad_magnitude > 1e-8, f"Gradients too small for differentiable method {method}: {grad_magnitude:.2e}"
-    print(
-        f"   ✅ Non-zero gradients detected (magnitude: {grad_magnitude:.2e})")
+    assert grad_magnitude > 1e-8, (
+        f"Gradients too small for differentiable method {method}: {grad_magnitude:.2e}"
+    )
+    print(f"   ✅ Non-zero gradients detected (magnitude: {grad_magnitude:.2e})")
+
+
+@pytest.mark.single_device
+def test_spherical_visibility_mask_center_covers_all_pixels():
+    nside = 8
+    mask = spherical_visibility_mask(
+        nside=nside,
+        observer_position=jnp.array([0.5, 0.5, 0.5], dtype=jnp.float32),
+    )
+    mask_np = np.asarray(mask)
+    assert mask_np.shape == (hp.nside2npix(nside), )
+    assert np.all(mask_np == 1.0)
+
+
+@pytest.mark.single_device
+def test_spherical_visibility_mask_corner_has_partial_coverage():
+    nside = 8
+    mask = spherical_visibility_mask(
+        nside=nside,
+        observer_position=jnp.array([0.0, 0.0, 0.0], dtype=jnp.float32),
+    )
+    mask_np = np.asarray(mask)
+    assert mask_np.shape == (hp.nside2npix(nside), )
+    assert np.any(mask_np == 1.0)
+    assert np.any(mask_np == 0.0)
 
 
 @pytest.mark.single_device
@@ -415,6 +441,64 @@ def test_ngp_zero_gradients(positions_lpt, method, kwargs):
     grad_magnitude = jnp.abs(gradient)
     assert grad_magnitude == 0.0, f"Non-zero gradient for non-differentiable method {method}: {grad_magnitude:.2e}"
     print(f"   ✅ Zero gradients confirmed (magnitude: {grad_magnitude:.2e})")
+
+
+@pytest.mark.single_device
+@pytest.mark.parametrize("obs_x", [0.0, 0.25, 0.5, 0.75, 1.0])
+@pytest.mark.parametrize("obs_y", [0.0, 0.25, 0.5, 0.75, 1.0])
+@pytest.mark.parametrize("obs_z", [0.0, 0.25, 0.5, 0.75, 1.0])
+def test_spherical_visibility_mask_vs_painting(obs_x, obs_y, obs_z):
+    """Test analytical visibility mask against empirical painting."""
+    nside = 32
+    n_particles = 64
+
+    observer_pos_normalized = jnp.array([obs_x, obs_y, obs_z], dtype=jnp.float32)
+    observer_pos_physical = observer_pos_normalized * jnp.array(BOX_SIZE)
+
+    mesh_shape_test = (n_particles, n_particles, n_particles)
+    particles = jnp.stack(
+        jnp.meshgrid(*[jnp.arange(s) for s in mesh_shape_test], indexing="ij"),
+        axis=-1
+    )
+
+    R_min = 10.0
+    R_max = 2000.0
+
+    painted_map = paint_particles_spherical(
+        particles,
+        method="ngp",
+        nside=nside,
+        observer_position=observer_pos_physical,
+        R_min=R_min,
+        R_max=R_max,
+        box_size=BOX_SIZE,
+        mesh_shape=mesh_shape_test,
+    )
+
+    analytical_mask = spherical_visibility_mask(
+        nside=nside,
+        observer_position=observer_pos_normalized,
+    )
+
+    painted_np = np.asarray(painted_map)
+    mask_np = np.asarray(analytical_mask)
+    painted_np = np.where(painted_np < 1e-12, 0.0, 1.0)
+
+    invisible_pixels = (mask_np == 0.0)
+    if np.any(invisible_pixels):
+        violations = painted_np[invisible_pixels] > 0
+        if np.any(violations):
+            n_violations = violations.sum()
+            total_invisible = invisible_pixels.sum()
+            violation_rate = n_violations / total_invisible
+            assert violation_rate < 0.02, \
+                f"Observer at {observer_pos_normalized}: {n_violations}/{total_invisible} " \
+                f"({violation_rate:.2%}) invisible pixels have painted particles (>2% threshold)"
+
+    visible_pixels = (mask_np == 1.0)
+    if np.any(visible_pixels):
+        assert np.any(painted_np[visible_pixels] > 0.0), \
+            f"Observer at {observer_pos_normalized}: no particles painted where mask=1"
 
 
 @pytest.mark.single_device

--- a/tests/test_spherical_painting_methods.py
+++ b/tests/test_spherical_painting_methods.py
@@ -31,7 +31,8 @@ from jax_cosmo.redshift import redshift_distribution
 from jaxpm.distributed import fft3d
 from jaxpm.growth import growth_factor as jpm_growth_factor
 from jaxpm.pm import linear_field, lpt, pm_forces
-from jaxpm.spherical import paint_particles_spherical, spherical_visibility_mask
+from jaxpm.spherical import (paint_particles_spherical,
+                             spherical_visibility_mask)
 
 # ----------------------
 # Fixed configuration
@@ -363,7 +364,8 @@ def test_spherical_painting_differentiability(positions_lpt, method, kwargs):
     assert grad_magnitude > 1e-8, (
         f"Gradients too small for differentiable method {method}: {grad_magnitude:.2e}"
     )
-    print(f"   ✅ Non-zero gradients detected (magnitude: {grad_magnitude:.2e})")
+    print(
+        f"   ✅ Non-zero gradients detected (magnitude: {grad_magnitude:.2e})")
 
 
 @pytest.mark.single_device
@@ -452,14 +454,14 @@ def test_spherical_visibility_mask_vs_painting(obs_x, obs_y, obs_z):
     nside = 32
     n_particles = 64
 
-    observer_pos_normalized = jnp.array([obs_x, obs_y, obs_z], dtype=jnp.float32)
+    observer_pos_normalized = jnp.array([obs_x, obs_y, obs_z],
+                                        dtype=jnp.float32)
     observer_pos_physical = observer_pos_normalized * jnp.array(BOX_SIZE)
 
     mesh_shape_test = (n_particles, n_particles, n_particles)
-    particles = jnp.stack(
-        jnp.meshgrid(*[jnp.arange(s) for s in mesh_shape_test], indexing="ij"),
-        axis=-1
-    )
+    particles = jnp.stack(jnp.meshgrid(
+        *[jnp.arange(s) for s in mesh_shape_test], indexing="ij"),
+                          axis=-1)
 
     R_min = 10.0
     R_max = 2000.0


### PR DESCRIPTION
This pull request introduces a new analytical method for determining geometric visibility in spherical projections and adds a comprehensive set of tests to validate its correctness. The main addition is the `spherical_visibility_mask` function, which computes which pixels are visible from a given observer position in a unit cube, and several new tests ensure its accuracy and consistency with empirical painting results.

**New spherical visibility mask functionality:**

* Added the `spherical_visibility_mask` function to `jaxpm/spherical.py`, which computes a vectorized geometric mask indicating which Healpix pixels are visible from a given observer position inside the unit cube. This method uses robust slab intersection logic and is JIT-compiled for efficiency.

**Test coverage for visibility mask:**

* Imported `spherical_visibility_mask` in `tests/test_spherical_painting_methods.py` and added tests to verify that an observer at the cube center sees all pixels, and that an observer at a corner sees only a subset of pixels. [[1]](diffhunk://#diff-bd8becb91682a75037152771170294afccbdf6f3308ca29affbfbf38611eca18L34-R35) [[2]](diffhunk://#diff-bd8becb91682a75037152771170294afccbdf6f3308ca29affbfbf38611eca18L363-R395)
* Added a parameterized test that compares the analytical visibility mask against the empirical output of `paint_particles_spherical` across a grid of observer positions, asserting that invisible pixels do not get painted and that visible pixels have painted particles, with a strict threshold for violations.